### PR TITLE
Prueba reporte jacoco

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
+    <output.directory.coverage.report>${project.reporting.outputDirectory}/reporte-cobertura</output.directory.coverage.report>
   </properties>
 
   <dependencies>
@@ -77,6 +78,17 @@
             </goals>
           </execution>
           <execution>
+            <id>Crear Reporte de Cobertura</id>
+            <phase>test</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+            <configuration>
+              <dataFile>target/jacoco.exec</dataFile>
+              <outputDirectory>${output.directory.coverage.report}</outputDirectory>
+            </configuration>
+          </execution>
+          <execution>
             <id>Validar Cobertura</id>
             <phase>verify</phase>
             <goals>
@@ -95,6 +107,51 @@
                   </limits>
                 </rule>
               </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <version>3.0.0</version>
+        <executions>
+          <execution>
+            <id>Mostrar y Abrir Reporte Cobertura</id>
+            <phase>test</phase>
+            <configuration>
+              <target>
+                <echo level="info">"Reporte: ${project.reporting.outputDirectory}/reporte-cobertura/"</echo>
+                <echo level="info">Abra el archivo index.html navegador web</echo>
+                <script language="javascript"><![CDATA[
+                  location = "file:///${project.reporting.outputDirectory}/reporte-cobertura/index.html";
+                  java.awt.Desktop.getDesktop().browse(java.net.URI.create(location));
+                  ]]>
+                </script>
+              </target>
+            </configuration>
+            <goals>
+              <goal>run</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.gmaven</groupId>
+        <artifactId>groovy-maven-plugin</artifactId>
+        <version>2.0</version>
+        <executions>
+          <execution>
+            <id>Show Reporte Cobertura</id>
+            <phase>test</phase>
+            <goals>
+              <goal>execute</goal>
+            </goals>
+            <configuration>
+              <source>
+                log.info('Reporte Cobertura: {}', ' ${project.reporting.outputDirectory}/reporte-cobertura/')
+                log.info('Abra el archivo index.html con un navegador web')
+              </source>
             </configuration>
           </execution>
         </executions>

--- a/src/main/java/ar/edu/utn/frba/dds/pepita/Golondrina.java
+++ b/src/main/java/ar/edu/utn/frba/dds/pepita/Golondrina.java
@@ -1,0 +1,21 @@
+package ar.edu.utn.frba.dds.pepita;
+
+public class Golondrina {
+  private int energia;
+
+  public Golondrina(int energia) {
+    this.energia = energia;
+  }
+
+  public void volar() {
+    energia -= 10;
+  }
+
+  public void comer(int alpiste) {
+    energia += alpiste * 3;
+  }
+
+  public int getEnergia() {
+    return energia;
+  }
+}


### PR DESCRIPTION
### Agrega el gol - report de Jacoco

- Para las pruebas lo puse en la fase `test` aunque lo podemos dejar también en la fase `verify`. 

Algunas imágenes de cómo se ve el reporte.
![image](https://user-images.githubusercontent.com/11875266/115186687-89b99680-a0b8-11eb-968d-46c209de8222.png)
![image](https://user-images.githubusercontent.com/11875266/115186712-93db9500-a0b8-11eb-856f-38813c7840d4.png)


Por otro lado para que no quede tan oculto que se generó el repo podemos hacer algunas de estas cosas:

#### Opción 1: Abrirlo.
Lo mejor que encontré para hacer esto es el plugin [maven-antrun-plugin](https://maven.apache.org/plugins/maven-antrun-plugin/) que te permite ejecutar en el build  cualquier cosa que ejecutarías con [ant apache](https://ant.apache.org/)

```
<target>
  <echo level="info">"Reporte: ${project.reporting.outputDirectory}/reporte-cobertura/"</echo>
  <echo level="info">Abra el archivo index.html navegador web</echo>
  <script language="javascript"><![CDATA[
    location = "file:///${project.reporting.outputDirectory}/reporte-cobertura/index.html";
    java.awt.Desktop.getDesktop().browse(java.net.URI.create(location));
    ]]>
  </script>
</target>
```

![image](https://user-images.githubusercontent.com/11875266/115185979-44e13000-a0b7-11eb-867e-7f004886485b.png)

Obviamente se puede hacer mejor, por ejemplo terminar llamando a una clase que tenga la lógica y los controles para tratar de abrirlo en caso de que exista, poner más controles, etc. Aun haciendo esto último me sigue pareciendo bastante turbio.


Opción 1: Loguear info relacionada

Por ejemplo, en donde encontrarlo, como abrilo, etc. 
Si lo corres desde intellij es lo suficiente inteligente para linkearlo como se muestra en la siguiente imagen:

![image](https://user-images.githubusercontent.com/11875266/115185940-3430ba00-a0b7-11eb-80a0-8bb9f2a05185.png)

No encontré un plugin dentro de los habilitados de maven para loguearlo  así. El más cercano, de nuevo, es el maven-antrun-plugin con los `echo` pero no me gusta como termina mostrandolo, no es tan directo. Después esta este de `groovy-maven-plugin` y otro que encontré es [khmarbaise.github.io-echo-maven-plugin](http://khmarbaise.github.io/echo-maven-plugin/). Para hacer esto, cualquiera de los dos cumple. La contra, no son de apache.